### PR TITLE
refactor: 延长 git ls-remote 的超时时间

### DIFF
--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -152,7 +152,7 @@ class DockerService:
                     ['git', 'ls-remote', '--heads', auth_url],
                     capture_output=True,
                     text=True,
-                    timeout=10,  # 10-second timeout
+                    timeout=30,  # 30-second timeout
                     check=True
                 )
                 


### PR DESCRIPTION
将获取远程分支的超时时间从 10 秒增加到 30 秒，以提高在慢速网络下的稳定性。